### PR TITLE
Fix 'onScriptLoaded is undefined'

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,6 +9,7 @@
       {
         "loose": false
       }
-    ]
+    ],
+    "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -69,6 +69,14 @@ const removeFailedScript = () => {
 
 const scriptLoader = (...scripts) => (WrappedComponent) => {
   class ScriptLoader extends Component {
+    static defaultProps = {
+      onScriptLoaded: noop
+    };
+
+    static propTypes = {
+      onScriptLoaded: PropTypes.func
+    };
+
     constructor(props, context) {
       super(props, context)
 
@@ -119,13 +127,5 @@ const scriptLoader = (...scripts) => (WrappedComponent) => {
 
   return hoistStatics(ScriptLoader, WrappedComponent)
 }
-
-scriptLoader.defaultProps = {
-  onScriptLoaded: noop
-};
-
-scriptLoader.propTypes = {
-  onScriptLoaded: PropTypes.func
-};
 
 export default scriptLoader


### PR DESCRIPTION
`onScriptLoaded` should be added to `ScriptLoader` instead of `scriptLoader`, otherwise it will throw error 'onScriptLoaded is undefined' when it is not provided.